### PR TITLE
Add loopback.cfg

### DIFF
--- a/menus/autoiso.cfg
+++ b/menus/autoiso.cfg
@@ -39,10 +39,14 @@ function loopback_iso_entry {
 	set cfg_path="$4"
 
 	export iso_path
-	loopback loopdev_cfg "${device}${iso_path}"
-	set root=(loopdev_cfg)
+	set loopname=loopdev_cfg
+	while [ -d "(${loopname})/" ]; do
+		set loopname=${loopname}_2
+	done
+	loopback $loopname "${device}${iso_path}"
+	set root="(${loopname})"
 	configfile $cfg_path
-	loopback -d loopdev_cfg
+	loopback -d $loopname
     }
     return 0
 }

--- a/menus/loopback.cfg
+++ b/menus/loopback.cfg
@@ -1,0 +1,18 @@
+# Super Grub Disk - loopback.cfg
+# Copyright (C) 2009,2010,2011,2012,2013,2014,2015  Adrian Gibanel Lopez.
+#
+# Super Grub Disk is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Super Grub Disk is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Super Grub Disk.  If not, see <http://www.gnu.org/licenses/>.
+
+set prefix=(${root})/boot/grub
+source "${prefix}/grub.cfg"


### PR DESCRIPTION
Super Grub Disk started all that loopback.cfg support, but it is a pity that it does not include a loopback.cfg itself so that it can be started from another loopback.cfg supporting USB boot loader setup.

Tested with grml-plus, multiboot-usb, with the autoiso.cfg from the GRUB2 repository, with another copy of Super Grub Disk, as well as with my custom autoiso script I am using on my own emergency USB key.

I did not test all the menu options but those I tested worked fine.