### PR TITLE
Skip afd menu if missing

### DIFF
--- a/menus/grub.cfg
+++ b/menus/grub.cfg
@@ -20,9 +20,11 @@ set sg2d_directory="${config_directory}/sgd"
 export sg2d_directory
 set afd_directory="${config_directory}"
 export afd_directory
+set afd_year=2012
+set afd_menu="${config_directory}/afd${afd_year}.cfg"
 
-if [ "$MONTH" -eq "4" -a "$DAY" -eq "1" ] ; then
-  configfile "${afd_directory}/afd2012.cfg"
+if [ -e "$afd_menu" -a "$MONTH" -eq "4" -a "$DAY" -eq "1" ] ; then
+  configfile "${afd_menu}"
 else
   configfile "${sg2d_directory}/main.cfg"
 fi


### PR DESCRIPTION
… because in one of my scenarios, it will be missing.
Also reduce diff impact of updating the year.